### PR TITLE
feat(timeline): scroll-driven timeline, drop react-vertical-timeline-component

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -43,7 +43,6 @@
   "overrides": {
     "flatted": "^3.4.0",
     "minimatch": "^3.1.3",
-    "react-intersection-observer": "latest",
   },
   "packages": {
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],

--- a/bun.lock
+++ b/bun.lock
@@ -19,7 +19,6 @@
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-syntax-highlighter": "^16.1.1",
-        "react-vertical-timeline-component": "4.0.0",
         "sharp": "^0.34.5",
         "tailwind-merge": "^3.5.0",
         "tailwindcss-animate": "^1.0.7",
@@ -39,7 +38,6 @@
   "trustedDependencies": [
     "@tailwindcss/oxide",
     "sharp",
-    "react-vertical-timeline-component",
     "unrs-resolver",
   ],
   "overrides": {
@@ -407,8 +405,6 @@
     "character-reference-invalid": ["character-reference-invalid@2.0.1", "", {}, "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw=="],
 
     "class-variance-authority": ["class-variance-authority@0.7.1", "", { "dependencies": { "clsx": "^2.1.1" } }, "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg=="],
-
-    "classnames": ["classnames@2.5.1", "", {}, "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow=="],
 
     "client-only": ["client-only@0.0.1", "", {}, "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="],
 
@@ -932,13 +928,9 @@
 
     "react-dom": ["react-dom@19.2.4", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.4" } }, "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ=="],
 
-    "react-intersection-observer": ["react-intersection-observer@10.0.3", "", { "peerDependencies": { "react": "^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0" }, "optionalPeers": ["react-dom"] }, "sha512-luICLMbs0zxTO/70Zy7K5jOXkABPEVSAF8T3FdZUlctsrIaPLmx8TZe2SSA+CY2HGWfz2INyNTnp82pxNNsShA=="],
-
     "react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
 
     "react-syntax-highlighter": ["react-syntax-highlighter@16.1.1", "", { "dependencies": { "@babel/runtime": "^7.28.4", "highlight.js": "^10.4.1", "highlightjs-vue": "^1.0.0", "lowlight": "^1.17.0", "prismjs": "^1.30.0", "refractor": "^5.0.0" }, "peerDependencies": { "react": ">= 0.14.0" } }, "sha512-PjVawBGy80C6YbC5DDZJeUjBmC7skaoEUdvfFQediQHgCL7aKyVHe57SaJGfQsloGDac+gCpTfRdtxzWWKmCXA=="],
-
-    "react-vertical-timeline-component": ["react-vertical-timeline-component@4.0.0", "", { "dependencies": { "classnames": "^2.2.6", "prop-types": "^15.8.1", "react-intersection-observer": "^9.5.3" }, "peerDependencies": { "react": "^16.8.6 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.6 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-XVo+3f6ZByHN34livr+WylEMNfZ+YdOK998NS1YoUYOUyECxrZZHLrMk4U+PF4mCIFrtNnDEosr07Z97ivU+Rg=="],
 
     "recma-build-jsx": ["recma-build-jsx@1.0.0", "", { "dependencies": { "@types/estree": "^1.0.0", "estree-util-build-jsx": "^3.0.0", "vfile": "^6.0.0" } }, "sha512-8GtdyqaBcDfva+GUKDr3nev3VpKAhup1+RvkMvUxURHpW7QyIvk9F5wz7Vzo06CEMSilw6uArgRqhpiUcWp8ew=="],
 

--- a/components/Index/Timeline/Timeline.js
+++ b/components/Index/Timeline/Timeline.js
@@ -77,8 +77,8 @@ const Timeline = () => {
       </div>
 
       <div ref={ref} className='relative pb-20'>
-        {timelineData.map(({ date, header, organization, qualities, Icon }, index) => (
-          <div key={index} className='flex justify-start pt-10 md:gap-10 md:pt-24'>
+        {timelineData.map(({ date, header, organization, qualities, Icon }) => (
+          <div key={date} className='flex justify-start pt-10 md:gap-10 md:pt-24'>
             {/* Sticky left: dot + date */}
             <div className='sticky top-28 z-20 flex max-w-xs flex-col items-center self-start md:w-full md:max-w-sm md:flex-row'>
               <div className='absolute left-2 flex h-12 w-12 items-center justify-center rounded-full bg-stone-400 ring-4 ring-[#0097A7] md:left-2'>

--- a/components/Index/Timeline/Timeline.js
+++ b/components/Index/Timeline/Timeline.js
@@ -1,9 +1,6 @@
 'use client'
-import {
-  VerticalTimeline,
-  VerticalTimelineElement
-} from 'react-vertical-timeline-component'
-import 'react-vertical-timeline-component/style.min.css'
+import { useScroll, useTransform, motion } from 'framer-motion'
+import { useEffect, useRef, useState } from 'react'
 import { Laptop, MicVocal, Users, BriefcaseBusiness } from 'lucide-react'
 import Heading from '../Heading'
 
@@ -12,78 +9,108 @@ const timelineData = [
     date: '2024-Present',
     header: 'SDE',
     organization: (
-      <a target='_blank' href='https://www.n7.io' rel='noopener noreferrer'>
+      <a
+        target='_blank'
+        href='https://www.n7.io'
+        rel='noopener noreferrer'
+        className='underline decoration-cyan-500/60 underline-offset-2 transition-colors hover:text-cyan-300'
+      >
         N7
       </a>
     ),
     qualities: '',
-    icon: <BriefcaseBusiness className='text-stone-700' />
+    Icon: BriefcaseBusiness
   },
   {
     date: '2022-2024',
     header: 'Projects Lead',
     organization: 'Research Cell',
     qualities: 'Leadership | Management | Research',
-    icon: <Users className='text-stone-700' />
+    Icon: Users
   },
   {
     date: '2021-2023',
     header: 'Website Team',
     organization: 'Computer Society of India (CSI)',
     qualities: 'WebDevelopment',
-    icon: <Laptop color='#000000' className='text-stone-700' />
+    Icon: Laptop
   },
   {
     date: '2021-2022',
     header: 'IEEE Event Speaker',
     organization: 'Institute of Electrical and Electronics Engineers',
     qualities: 'Public Speaking | Community Contribution',
-    icon: <MicVocal className='text-stone-700' />
+    Icon: MicVocal
   }
 ]
 
 const Timeline = () => {
+  const ref = useRef(null)
+  const containerRef = useRef(null)
+  const [height, setHeight] = useState(0)
+
+  useEffect(() => {
+    if (!ref.current) return
+    const measure = () => setHeight(ref.current.getBoundingClientRect().height)
+    measure()
+    const observer = new ResizeObserver(measure)
+    observer.observe(ref.current)
+    return () => observer.disconnect()
+  }, [])
+
+  const { scrollYProgress } = useScroll({
+    target: containerRef,
+    offset: ['start 10%', 'end 50%']
+  })
+
+  const heightTransform = useTransform(scrollYProgress, [0, 1], [0, height])
+  const opacityTransform = useTransform(scrollYProgress, [0, 0.1], [0, 1])
+
   return (
-    <div className='max-w-(--breakpoint-xl) overflow-x-hidden mx-auto' id='positions'>
+    <div
+      className='max-w-(--breakpoint-xl) mx-auto overflow-x-hidden'
+      id='positions'
+      ref={containerRef}
+    >
       <div className='text-white'>
-        <Heading
-          title={'Positions'}
-          details={'Position I have been trusted with'}
-        />
+        <Heading title={'Positions'} details={'Position I have been trusted with'} />
       </div>
-      <VerticalTimeline
-        animate={true}
-        layout='2-columns'
-        lineColor='#0097A7'
-        className='md:relative md:left-2'
-      >
-        {timelineData.map(
-          ({ date, header, organization, qualities, icon }, index) => {
-            return (
-              <VerticalTimelineElement
-                key={index}
-                contentArrowStyle={{ borderRight: '7px solid #a5f3fc' }}
-                iconStyle={{
-                  background: '#a3a3a3',
-                  boxShadow: '0 0 0 4px #0097A7'
-                }}
-                date={date}
-                dateClassName='text-white'
-                icon={icon}
-                contentStyle={{
-                  background: 'rgb(68 64 60 / 0.6)',
-                  color: 'white',
-                  boxShadow: '2px 5px 4px 0px #0097A7'
-                }}
-              >
-                <h3 className=''>{header}</h3>
-                <h6 className=''>{organization}</h6>
-                <p>{qualities}</p>
-              </VerticalTimelineElement>
-            )
-          }
-        )}
-      </VerticalTimeline>
+
+      <div ref={ref} className='relative pb-20'>
+        {timelineData.map(({ date, header, organization, qualities, Icon }, index) => (
+          <div key={index} className='flex justify-start pt-10 md:gap-10 md:pt-24'>
+            {/* Sticky left: dot + date */}
+            <div className='sticky top-28 z-20 flex max-w-xs flex-col items-center self-start md:w-full md:max-w-sm md:flex-row'>
+              <div className='absolute left-2 flex h-12 w-12 items-center justify-center rounded-full bg-stone-400 ring-4 ring-[#0097A7] md:left-2'>
+                <Icon className='h-5 w-5 text-stone-800' aria-hidden='true' />
+              </div>
+              <h3 className='hidden text-4xl font-bold text-stone-400 md:block md:pl-24 lg:text-5xl'>
+                {date}
+              </h3>
+            </div>
+
+            {/* Right: content card */}
+            <div className='relative w-full pl-20 pr-2 md:pl-4'>
+              <h3 className='mb-2 block text-2xl font-bold text-stone-400 md:hidden'>
+                {date}
+              </h3>
+              <div className='rounded-lg bg-stone-700/60 p-5 text-white shadow-[2px_5px_4px_0px_#0097A7] backdrop-blur-sm'>
+                <h4 className='text-xl font-semibold'>{header}</h4>
+                <h5 className='text-cyan-100'>{organization}</h5>
+                {qualities && <p className='mt-1 text-sm text-stone-300'>{qualities}</p>}
+              </div>
+            </div>
+          </div>
+        ))}
+
+        {/* Progress line */}
+        <div className='absolute left-8 top-0 w-[2px] overflow-hidden bg-stone-600/40 [mask-image:linear-gradient(to_bottom,transparent_0%,black_10%,black_90%,transparent_100%)]' style={{ height: height + 'px' }}>
+          <motion.div
+            style={{ height: heightTransform, opacity: opacityTransform }}
+            className='absolute inset-x-0 top-0 w-[2px] rounded-full bg-gradient-to-t from-cyan-500 via-[#0097A7] to-cyan-200'
+          />
+        </div>
+      </div>
     </div>
   )
 }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-syntax-highlighter": "^16.1.1",
-    "react-vertical-timeline-component": "4.0.0",
     "sharp": "^0.34.5",
     "tailwind-merge": "^3.5.0",
     "tailwindcss-animate": "^1.0.7",
@@ -54,7 +53,6 @@
   },
   "trustedDependencies": [
     "@tailwindcss/oxide",
-    "react-vertical-timeline-component",
     "sharp",
     "unrs-resolver"
   ],

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "tailwindcss": "^4.2.2"
   },
   "overrides": {
-    "react-intersection-observer": "latest",
     "minimatch": "^3.1.3",
     "flatted": "^3.4.0"
   },


### PR DESCRIPTION
## Summary
Replaces the unmaintained `react-vertical-timeline-component` (exact-pinned `4.0.0`) with a self-contained, scroll-driven timeline — the Aceternity-style left-sticky pattern, **with zero new dependencies**.

Built on `framer-motion` (already installed) + tailwind + the existing `cn`/theme. Aceternity's own package was overkill, so only the pattern was adapted, not the dep.

## What changed
- **New `Timeline.js`**: sticky left date + icon dot, glass content cards on the right, a vertical progress line that fills as you scroll (`useScroll` / `useTransform`).
- `ResizeObserver` keeps the progress-line height in sync with content height.
- Restyled to the site's existing **cyan `#0097A7` + stone dark-glass** theme (matches the old look, not Aceternity's neutral default).
- Removed `react-vertical-timeline-component` from `dependencies` **and** `trustedDependencies`. Net: one fewer dependency.

## Verification
- `bun run build` ✅ exit 0, 13 routes generated, TypeScript clean.
- Scroll animation is best eyeballed via `bun dev` → `#positions` section.

## Notes
- Branched off `main`, independent of the deps-update PR (#16). No overlap beyond `package.json`/lock; trivial to rebase if #16 merges first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)