### PR TITLE
fix(timeline): guard ResizeObserver against detached node

### DIFF
--- a/components/Index/Timeline/Timeline.js
+++ b/components/Index/Timeline/Timeline.js
@@ -50,11 +50,12 @@ const Timeline = () => {
   const [height, setHeight] = useState(0)
 
   useEffect(() => {
-    if (!ref.current) return
-    const measure = () => setHeight(ref.current.getBoundingClientRect().height)
+    const node = ref.current
+    if (!node) return
+    const measure = () => setHeight(node.getBoundingClientRect().height)
     measure()
     const observer = new ResizeObserver(measure)
-    observer.observe(ref.current)
+    observer.observe(node)
     return () => observer.disconnect()
   }, [])
 


### PR DESCRIPTION
## Bug
`Cannot read properties of null (reading 'getBoundingClientRect')` in `Timeline.js`.

The measure callback read `ref.current` **at call time**:
```js
const measure = () => setHeight(ref.current.getBoundingClientRect().height)
```
A `ResizeObserver` can fire its callback after the observed node detaches (React fast refresh, unmount, route change), at which point `ref.current` is `null` → throw.

## Fix
Capture the node in a local variable inside the effect and observe/measure that, so the closure can't see a nulled-out ref.

```js
const node = ref.current
if (!node) return
const measure = () => setHeight(node.getBoundingClientRect().height)
```

## Verification
- `bun run build` ✅ exit 0